### PR TITLE
Add Smithery to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Personal MCP Server
 
+[![smithery badge](https://smithery.ai/badge/personal-mcp)](https://smithery.ai/server/personal-mcp)
+
 A Model Context Protocol server for personal health and well-being tracking. This server provides tools and resources for tracking workouts, nutrition, and daily journal entries, with AI-assisted analysis through Claude integration.
 
 ## Features
@@ -29,6 +31,14 @@ A Model Context Protocol server for personal health and well-being tracking. Thi
 - Pattern recognition in mood and energy levels
 
 ## Installation
+
+### Installing via Smithery
+
+To install Personal Health Tracker for Claude Desktop automatically via [Smithery](https://smithery.ai/server/personal-mcp):
+
+```bash
+npx -y @smithery/cli install personal-mcp --client claude
+```
 
 ### Prerequisites
 - Python 3.10 or higher


### PR DESCRIPTION
This PR makes two changes to the README.

1. Adds installation instructions to automatically install Personal Health Tracker for Claude Desktop using Smithery CLI. This makes it easier for users to install the MCP.
2. Adds a badge to show the number of installations from Smithery: https://smithery.ai/server/personal-mcp

Let me know if any tweaks have to be made!